### PR TITLE
app server - no command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,6 @@ services:
         condition: service_healthy
     networks:
       - rag-network
-    command: ["npm", "run", "dev"]
 
 networks:
   rag-network:


### PR DESCRIPTION
I had trouble starting the service with this. The default "npm start" from the app/Dockerfile seemed sufficient.