### PR TITLE
ollama: no curl for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         reservations:
           memory: 4G
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD", "ollama", "ls"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Use ollama ls instead.

Not sure if its the best healthcheck but it seems to work.

curl isn't installed in the container.